### PR TITLE
Fixes for crispy-bootstrap4 error on templates 

### DIFF
--- a/grafiki/app/templates/upload_file.html
+++ b/grafiki/app/templates/upload_file.html
@@ -5,6 +5,6 @@
   <form method="post" enctype="multipart/form-data">
     {% csrf_token %}
     {{ form|crispy }}
-    <button type="submit" class="btn btn-primary">Uplaoad file</button>
+    <button type="submit" class="btn btn-primary">Upload file</button>
   </form>
 {% endblock %}

--- a/grafiki/grafiki/settings.py
+++ b/grafiki/grafiki/settings.py
@@ -25,7 +25,7 @@ SECRET_KEY = 'j-)4yu(bse8jw4f5v+6-%$f$v1t7#f6a7ug%(0%!=0nvux+sv&'
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = ['127.0.0.1', 'grafiki.local']
+ALLOWED_HOSTS = ['localhost', '127.0.0.1', 'grafiki.local']
 
 
 # Application definition
@@ -40,7 +40,8 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
-    'crispy_forms'
+    'crispy_forms',
+    'crispy_bootstrap4'
 ]
 
 CRISPY_TEMPLATE_PACK = 'bootstrap4'

--- a/setup.sh
+++ b/setup.sh
@@ -7,4 +7,4 @@ sudo -u postgres psql -d grafiki -a -f initial.sql
 
 # Install dependencies
 sudo apt install python3 python3-pip libpq-dev -y
-pip3 install elasticsearch_dsl django psycopg2 djangorestframework django-crispy-forms evtx
+pip3 install elasticsearch_dsl django psycopg2 djangorestframework django-crispy-forms crispy-bootstrap4 evtx


### PR DESCRIPTION
As of django-crispy-forms 2.0 the template packs are now in a separate package in crispy_bootstrap4